### PR TITLE
Add products so it can be added to SPI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 let package = Package(
     name: "timeui",
     platforms: [.macOS(.v11)],
+    products: [.executable(name: "timeui", targets: ["timeui"])],
     targets: [
         .executableTarget(
             name: "test-app"


### PR DESCRIPTION
I wanted to [add it to SPI](https://github.com/SwiftPackageIndex/PackageList/runs/6651396584?check_suite_focus=true) but we check for products in the manifest:

```
ERROR: package has no products: https://github.com/icanzilb/timeui.git
```

If you fancy having it in the index, this should fix it :)